### PR TITLE
Smooth fade for song list overlay

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -227,7 +227,8 @@ body {
     width: 100%;
     height: 100vh;
     z-index: 1;
-    transition: bottom 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
+    transition: bottom 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94),
+                opacity 0.6s cubic-bezier(0.25, 0.46, 0.45, 0.94);
     overflow-x: visible;
     overflow-y: hidden;
     opacity: 0;
@@ -248,7 +249,6 @@ body {
 
 .svg-background.slide-down {
     bottom: -100vh !important;
-    opacity: 0 !important;
     pointer-events: none !important;
 }
 


### PR DESCRIPTION
## Summary
- Fade `.svg-background` opacity alongside bottom to avoid flash when closing song list
- Remove forced opacity from `.svg-background.slide-down` so overlay fades during slide

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68afc4879364832fa039691a003b3857